### PR TITLE
fix: incorrect babel preset/plugin order cause error

### DIFF
--- a/packages/plugin-webpack-react/src/arco-design-plugin/plugin-for-import.ts
+++ b/packages/plugin-webpack-react/src/arco-design-plugin/plugin-for-import.ts
@@ -30,7 +30,7 @@ export class ImportPlugin {
         const tsLoaderIndex = getLoaderIndex(loaders, 'ts-loader');
         let insertIndex = loaders.length - 1;
         if (babelLoaderIndex > -1) {
-          insertIndex = babelLoaderIndex + 1;
+          insertIndex = babelLoaderIndex;
         } else if (tsLoaderIndex > -1) {
           insertIndex = (tsLoaderIndex || 1) - 1;
         }


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.
  
  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design-pro/blob/master/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

A project with `@arco-plugins/webpack-react` causes `babel-plugin-transform-react-jsx` invalid.

Create a ArcoPro project (select CRA) and a normal CRA project to verify the case:

1. remove the unnecessary imports ( CRA has supported [the new JSX transform](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) )
```ts
// import React from 'react';
```

2. the ArcoPro project causes an error `ReferenceError: React is not defined`

> the original `babel/preset-react` options: `{ runtime: 'automatic' }`
> but got the options: `{ runtime: 'classic' }`.

3. the CRA project works fine

## Solution

<!-- Describe how the problem is fixed in detail -->

```diff
if (babelLoaderIndex > -1) {
-  insertIndex = babelLoaderIndex + 1;
+  insertIndex = babelLoaderIndex;
} else if (tsLoaderIndex > -1) {
  insertIndex = (tsLoaderIndex || 1) - 1;
}
```

Makes the injected loader after the babel-loader.

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

see ## Background and context

## Changelog

| Changelog(CN) | Changelog(EN) | Related issues | 
| -------------- | -------------- | -------------- |
| 修复 babel-loader 注入顺序导致 babel 预设配置被覆盖的问题  |  Fix the issue that the babel-loader injection order causes the babel presets' options to be covered   | -------------- |

## Checklist:

- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `master` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->