### PR TITLE
fix：js 文件中的 jsx 语法支持

### DIFF
--- a/packages/plugin-vite-vue/package.json
+++ b/packages/plugin-vite-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arco-plugins/vite-vue",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "For Vite build, load Arco Design styles on demand",
   "main": "lib/index.js",
   "types": "types/index.d.ts",

--- a/packages/plugin-vite-vue/src/arco-design-plugin/transform.ts
+++ b/packages/plugin-vite-vue/src/arco-design-plugin/transform.ts
@@ -68,15 +68,7 @@ export function transformJsFiles({
     enter(path: NodePath) {
       const { node } = path;
       // <a-input-number></a-input-number>  <a-timeline-item></a-timeline-item> <component is="a-timeline-item"></component>
-      if (
-        /**
-         * support <script lang="jsx">
-         * @path *.vue?vue&type=script&lang.jsx
-         * @path *.vue?vue&type=script&setup=true&lang.jsx
-         */
-        /\.vue(\?vue&type=script(&setup=true)?&lang.[jt]s(x)?)?$/.test(id) &&
-        types.isCallExpression(node)
-      ) {
+      if (types.isCallExpression(node)) {
         const { callee, arguments: args } = node as any;
         const funcName = callee.name;
         const importedName = args?.[0]?.value;

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,7 +20,7 @@ __metadata:
   resolution: "@arco-design/color@npm:0.4.0"
   dependencies:
     color: ^3.1.3
-  checksum: b728a8d3e50f6074988b92b7f4f1c57e1ef285674411c2303995b502ecb5f67fb99de5714a9364765810de1f9c2a75272b3f34895c931c58e137d62302b362b1
+  checksum: 2e9e8a6c0992f12006011e11c42fee0acb3b7cc6ece69ce0b902f2b6071668cb71df09f95610df4606468168f00380d47c276ccbcbe82647bd293bd44b22eddd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
修正 tsx/jsx 文件中使用 `<a-input-number></a-input-number>` 这样的组件引入时不能按需引入样式的bug