### PR TITLE
fix(unplugin): correct unplugin-react plugin due to rspack deprecated buildin option

### DIFF
--- a/packages/unplugin-react/src/plugins/import.ts
+++ b/packages/unplugin-react/src/plugins/import.ts
@@ -10,27 +10,38 @@ export class ImportPlugin {
   }
 
   apply(compiler: Compiler) {
-    compiler.options.builtins.pluginImport ||= [];
+    compiler.options.module.rules ||= [];
 
-    compiler.options.builtins.pluginImport.push({
-      libraryDirectory: this.options.libraryDirectory || 'es',
-      style: this.options.style ?? true,
-      libraryName: ARCO_DESIGN_COMPONENT_NAME,
-      camelToDashComponentName: false,
-    });
+    const rule = {
+      test: /@arco-design\/web-react/,
+      exclude: [/node_modules/],
+      loader: 'builtin:swc-loader',
+      options: {
+        rspackExperiments: {
+          import: [
+            {
+              libraryDirectory: this.options.libraryDirectory || 'es',
+              style: ![null, undefined].includes(this.options.style) ? this.options.style : true,
+              libraryName: ARCO_DESIGN_COMPONENT_NAME,
+              camelToDashComponentName: false,
+            },
+            {
+              libraryName: ARCO_DESIGN_ICON_NAME,
+              libraryDirectory: 'react-icon',
+              camelToDashComponentName: false,
+            },
+            {
+              libraryName: this.options.iconBox,
+              libraryDirectory: 'esm',
+              camelToDashComponentName: false,
+            },
+          ],
+        },
+      },
+    };
 
-    compiler.options.builtins.pluginImport.push({
-      libraryName: ARCO_DESIGN_ICON_NAME,
-      libraryDirectory: 'react-icon',
-      camelToDashComponentName: false,
-    });
-
-    if (this.options.iconBox) {
-      compiler.options.builtins.pluginImport.push({
-        libraryName: this.options.iconBox,
-        libraryDirectory: 'esm',
-        camelToDashComponentName: false,
-      });
-    }
+    compiler.options.module.rules.push(rule);
   }
 }
+
+exports.ImportPlugin = ImportPlugin;

--- a/packages/unplugin-react/src/plugins/import.ts
+++ b/packages/unplugin-react/src/plugins/import.ts
@@ -42,7 +42,8 @@ export class ImportPlugin {
       compiler.options.module.rules ||= [];
 
       const rule = {
-        use: 'builtin:swc-loader',
+        test: /(jsx?|tsx?)$/,
+        loader: 'builtin:swc-loader',
         options: {
           rspackExperiments: {
             import: [

--- a/packages/unplugin-react/src/plugins/import.ts
+++ b/packages/unplugin-react/src/plugins/import.ts
@@ -73,5 +73,3 @@ export class ImportPlugin {
     }
   }
 }
-
-exports.ImportPlugin = ImportPlugin;

--- a/packages/unplugin-react/src/plugins/import.ts
+++ b/packages/unplugin-react/src/plugins/import.ts
@@ -10,37 +10,67 @@ export class ImportPlugin {
   }
 
   apply(compiler: Compiler) {
-    compiler.options.module.rules ||= [];
+    /**
+     * Compatible with the new rspack version
+     * due to since 0.63 removed options.builtins of compiler
+     * https://github.com/web-infra-dev/rspack/releases/tag/v0.6.3
+     */
+    if (compiler.options.builtins) {
+      compiler.options.builtins.pluginImport ||= [];
 
-    const rule = {
-      test: /@arco-design\/web-react/,
-      exclude: [/node_modules/],
-      loader: 'builtin:swc-loader',
-      options: {
-        rspackExperiments: {
-          import: [
-            {
-              libraryDirectory: this.options.libraryDirectory || 'es',
-              style: ![null, undefined].includes(this.options.style) ? this.options.style : true,
-              libraryName: ARCO_DESIGN_COMPONENT_NAME,
-              camelToDashComponentName: false,
-            },
-            {
-              libraryName: ARCO_DESIGN_ICON_NAME,
-              libraryDirectory: 'react-icon',
-              camelToDashComponentName: false,
-            },
-            {
-              libraryName: this.options.iconBox,
-              libraryDirectory: 'esm',
-              camelToDashComponentName: false,
-            },
-          ],
+      compiler.options.builtins.pluginImport.push({
+        libraryDirectory: this.options.libraryDirectory || 'es',
+        style: this.options.style ?? true,
+        libraryName: ARCO_DESIGN_COMPONENT_NAME,
+        camelToDashComponentName: false,
+      });
+
+      compiler.options.builtins.pluginImport.push({
+        libraryName: ARCO_DESIGN_ICON_NAME,
+        libraryDirectory: 'react-icon',
+        camelToDashComponentName: false,
+      });
+
+      if (this.options.iconBox) {
+        compiler.options.builtins.pluginImport.push({
+          libraryName: this.options.iconBox,
+          libraryDirectory: 'esm',
+          camelToDashComponentName: false,
+        });
+      }
+    } else {
+      compiler.options.module.rules ||= [];
+
+      const rule = {
+        test: /@arco-design\/web-react/,
+        exclude: [/node_modules/],
+        loader: 'builtin:swc-loader',
+        options: {
+          rspackExperiments: {
+            import: [
+              {
+                libraryDirectory: this.options.libraryDirectory || 'es',
+                style: ![null, undefined].includes(this.options.style) ? this.options.style : true,
+                libraryName: ARCO_DESIGN_COMPONENT_NAME,
+                camelToDashComponentName: false,
+              },
+              {
+                libraryName: ARCO_DESIGN_ICON_NAME,
+                libraryDirectory: 'react-icon',
+                camelToDashComponentName: false,
+              },
+              {
+                libraryName: this.options.iconBox,
+                libraryDirectory: 'esm',
+                camelToDashComponentName: false,
+              },
+            ],
+          },
         },
-      },
-    };
+      };
 
-    compiler.options.module.rules.push(rule);
+      compiler.options.module.rules.push(rule);
+    }
   }
 }
 

--- a/packages/unplugin-react/src/plugins/import.ts
+++ b/packages/unplugin-react/src/plugins/import.ts
@@ -42,27 +42,24 @@ export class ImportPlugin {
       compiler.options.module.rules ||= [];
 
       const rule = {
-        test: /@arco-design\/web-react/,
-        exclude: [/node_modules/],
-        loader: 'builtin:swc-loader',
+        use: 'builtin:swc-loader',
         options: {
           rspackExperiments: {
             import: [
               {
-                libraryDirectory: this.options.libraryDirectory || 'es',
-                style: ![null, undefined].includes(this.options.style) ? this.options.style : true,
+                customName: `${ARCO_DESIGN_COMPONENT_NAME}/${
+                  this.options.libraryDirectory || 'es'
+                }/{{member}}`,
+                style: this.options.style ?? true,
                 libraryName: ARCO_DESIGN_COMPONENT_NAME,
-                camelToDashComponentName: false,
               },
               {
                 libraryName: ARCO_DESIGN_ICON_NAME,
-                libraryDirectory: 'react-icon',
-                camelToDashComponentName: false,
+                customName: `${ARCO_DESIGN_ICON_NAME}/react-icon/{{member}}`,
               },
               {
                 libraryName: this.options.iconBox,
-                libraryDirectory: 'esm',
-                camelToDashComponentName: false,
+                customName: `${this.options.iconBox}/esm/{{member}}`,
               },
             ],
           },

--- a/packages/unplugin-react/src/plugins/remove-font-face.ts
+++ b/packages/unplugin-react/src/plugins/remove-font-face.ts
@@ -10,7 +10,6 @@ export class RemoveFontFacePlugin {
     };
     compiler.options.module.rules.push({
       test: compileGlob(`**/node_modules/${ARCO_DESIGN_COMPONENT_NAME}/{es,lib}/style/index.less`),
-      type: null,
       use: [use],
     });
   }


### PR DESCRIPTION
fix(unplugin): correct unplugin-react plugin due to rspack deprecated buildin option

<!--
  Thanks so much for your PR and contribution.
  
  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design-pro/blob/master/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change

## Background and context
Fix issue https://github.com/arco-design/arco-plugins/issues/61
<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution
Use `builtin:swc-loader` loader instead to legacy
<!-- Describe how the problem is fixed in detail -->

## How is the change tested?
N/A
<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Changelog(CN) | Changelog(EN) | Related issues | 
| ------------- | ------------- | -------------- |
| 修复 unpack-react 在 rspack 版本更新引起的启动错误 | Fix unpack-react startup errors on  rspack |  https://github.com/arco-design/arco-plugins/issues/61 |
## Checklist:

- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `master` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->