### PR TITLE
Add tsx parser to avoid node_module jsx error

### DIFF
--- a/packages/unplugin-react/src/plugins/import.ts
+++ b/packages/unplugin-react/src/plugins/import.ts
@@ -45,6 +45,12 @@ export class ImportPlugin {
         test: /(jsx?|tsx?)$/,
         loader: 'builtin:swc-loader',
         options: {
+          jsc: {
+            parser: {
+              syntax: 'typescript',
+              tsx: true,
+            },
+          },
           rspackExperiments: {
             import: [
               {


### PR DESCRIPTION
## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change

## Background and context
When matched jsx,tsx files in node_modules, rspack will not transform file content before import deal modify,
It will throws error see like:
![image](https://github.com/user-attachments/assets/7c989b51-c6e8-4c8f-8d5d-9b0efcb05400)


## Solution
Add the parser options to avoid this error 
https://swc.rs/docs/configuration/compilation#jscparser

## How is the change tested?
import someone npm' package include jsx source file
Use rspack dev/build

## Changelog

| Changelog(CN) | Changelog(EN) | Related issues | 
| ------------- | ------------- | -------------- |
| 修复 node_modules 中 jsx 文件诱发报错问题 | Avoid errors when import jsx file from node_modules | |

## Checklist:

- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `master` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->