### PR TITLE
fix: can not resolve arco component when using global vue component

### DIFF
--- a/packages/plugin-vite-vue/src/arco-design-plugin/transform.ts
+++ b/packages/plugin-vite-vue/src/arco-design-plugin/transform.ts
@@ -104,7 +104,7 @@ export function transformJsFiles({
         }
         if (
           !componentName ||
-          !['_resolveComponent', '_resolveDynamicComponent'].includes(funcName)
+          !/(_resolveComponent|_resolveDynamicComponent)/.test(funcName)
         ) {
           return;
         }


### PR DESCRIPTION
## Types of changes

- [ ] New feature
- [x ] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change

## Background and context

Arco Component Import not work when using global vue component in sfc.
Beacuse Arco Component's funcName is `_resolveComponent2`
[vue-sfc](https://play.vuejs.org/#eNqNUUFP8zAM/StWvsuHxLqxjQmVggSIAxwAARKXXkLrtRlpEiXuNoT233HaMXZAiJv9/Gw/P3+IC+eSZYsiFVkovHIEAal1oKWpznJBYZ2L89zkprAmELwsFnAGmRy8tkTWnB+NJ9lwl0VeNuzn9Alh47Qk5Awge5AVwrCP46QYZsM9DqeB3jVCKKzDkpFE28rCR2ypUVU1pTDD5jTmTpalMlUKR8nxFloprQdFzdoxhbnShL7DyUsTFClrvmCYjEZN4OJmuyOt7ZLhblNPSaH01g1CLUu7+j+CEYyxgX+z6ayYz6U82GuOFv55wHT8enIy2Q1gw+LJfKs4ZL/Z57mqkkWwhp/STctFYRunNPp7F28IuUj7PbEmtbar2w4j3+LhF17UWLz9gC/iS1MOHjwG9EvMxa5G0ldIffn66Q7XHO+KjS1bzexfio8YrG6jxp522ZqSZe/xOrU3jbOe+HfP4XpNyK/ZHhWFRuam4+eCbb365fRvuZNk2vWxo2LzCdqF8Nk=)

## Solution

replace includes with regex 

## How is the change tested?

local build

## Changelog

| Changelog(CN) | Changelog(EN) | Related issues | 
| 修复vue使用全局组件时没法auto import的问题 |  resolve the problem that can not auto import when using global vue component| -------------- |

## Checklist:

- [x ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `master` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->