### PR TITLE
feat: add rspack 2.0 support

### DIFF
--- a/packages/unplugin-react/package.json
+++ b/packages/unplugin-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arco-plugins/unplugin-react",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0-beta.6",
   "description": "arco plugin",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -37,6 +37,6 @@
     "typescript": "^5.0.4"
   },
   "peerDependencies": {
-    "@rspack/core": "^1.0.0 || ^1.0.0-alpha.0 || ^1.0.0-beta.0"
+    "@rspack/core": "^1.0.0 || ^2.0.0 || ^2.0.0-alpha.0 || ^2.0.0-beta.0"
   }
 }

--- a/packages/unplugin-react/src/plugins/import.ts
+++ b/packages/unplugin-react/src/plugins/import.ts
@@ -1,14 +1,15 @@
 import type { Compiler, SwcLoaderOptions } from '@rspack/core';
 import { ARCO_DESIGN_COMPONENT_NAME, ARCO_DESIGN_ICON_NAME } from '../config';
 import { ArcoDesignPluginOptions } from '../types';
+import { patchLoaderOptions } from '../utils/theme';
 
 function applySwcOptions(
   options: ArcoDesignPluginOptions,
-  rule: { options?: string | Record<string, any> },
+  ruleOptions: string | Record<string, any>,
   externals: string[]
 ) {
-  if (typeof rule.options !== 'object') return;
-  const swcLoaderOptions = rule.options as SwcLoaderOptions;
+  if (typeof ruleOptions !== 'object') return;
+  const swcLoaderOptions = ruleOptions as SwcLoaderOptions;
   swcLoaderOptions.rspackExperiments ||= {};
   swcLoaderOptions.rspackExperiments.import ||= [];
 
@@ -88,19 +89,8 @@ export class ImportPlugin {
 
       const rules = compiler.options.module.rules;
 
-      rules.forEach((rule) => {
-        if (typeof rule !== 'object') return;
-        if (rule.loader === 'builtin:swc-loader') {
-          applySwcOptions(this.options, rule, externals);
-          return;
-        }
-        if (Array.isArray(rule.use)) {
-          rule.use.forEach((ruleUse) => {
-            if (typeof ruleUse === 'object' && ruleUse.loader === 'builtin:swc-loader') {
-              applySwcOptions(this.options, ruleUse, externals);
-            }
-          });
-        }
+      patchLoaderOptions(rules, 'builtin:swc-loader', (options) => {
+        applySwcOptions(this.options, options, externals);
       });
     }
   }

--- a/packages/unplugin-react/src/plugins/theme.ts
+++ b/packages/unplugin-react/src/plugins/theme.ts
@@ -2,7 +2,7 @@ import type { Compiler } from '@rspack/core';
 import { ARCO_DESIGN_COMPONENT_NAME } from '../config';
 import { ArcoDesignPluginOptions } from '../types';
 import { compileGlob } from '../utils';
-import { getThemeComponents, getThemeTokens, patchLessOptions } from '../utils/theme';
+import { getThemeComponents, getThemeTokens, patchLoaderOptions } from '../utils/theme';
 
 export class ThemePlugin {
   options: ArcoDesignPluginOptions;
@@ -34,7 +34,7 @@ export class ThemePlugin {
     const prefixThemeTokensCache = new Map<string | undefined, Record<string, string>>([
       [undefined, themeTokens],
     ]);
-    patchLessOptions(compiler.options.module.rules, (originOptions = {}) => {
+    patchLoaderOptions(compiler.options.module.rules, 'less-loader', (originOptions = {}) => {
       if (!originOptions.lessOptions) originOptions.lessOptions = {};
       const prefix = originOptions.lessOptions.modifyVars?.['arco-cssvars-prefix'];
 

--- a/packages/unplugin-react/src/utils/theme.ts
+++ b/packages/unplugin-react/src/utils/theme.ts
@@ -59,24 +59,27 @@ export function getThemeTokens(theme: string): Record<string, string> {
   }
 }
 
-export function patchLessOptions(rules: RuleSetRules, updater: (originOptions: any) => void) {
+export function patchLoaderOptions(
+  rules: RuleSetRules | undefined,
+  loader: string,
+  updater: (originOptions: any) => void
+) {
+  if (!rules) return;
   function patchSingleUse(use: any) {
-    if (
-      typeof use === 'object' &&
-      'loader' in use &&
-      typeof use.loader === 'string' &&
-      use.loader.includes('less-loader')
-    ) {
-      if (!use.options) use.options = {};
-      updater(use.options);
-      return true;
+    if (typeof use?.loader !== 'string' || !use.loader.includes(loader)) {
+      return false;
     }
-    return false;
+    if (!use.options) use.options = {};
+    updater(use.options);
+    return true;
   }
 
-  rules.forEach((rule) => {
+  function traverseRuleSet(rule: RuleSetRules[number]) {
     if (!rule || rule === '...' || patchSingleUse(rule)) return;
+    if (Array.isArray(rule.oneOf)) return rule.oneOf.forEach((subRule) => traverseRuleSet(subRule));
     if (!rule.use || patchSingleUse(rule.use)) return;
     if (Array.isArray(rule.use)) rule.use.forEach((ruleUse) => patchSingleUse(ruleUse));
-  });
+  }
+
+  rules.forEach((rule) => traverseRuleSet(rule));
 }


### PR DESCRIPTION
## Types of changes

- [x] New feature

## Background and context

Rsbuild/Rspack v2 adjusted the loader config for less and swc within the `oneOf` rules. This PR adds support for this.

## Changelog

| Changelog(CN)  | Changelog(EN)          | Related issues |
| -------------- | ---------------------- | -------------- |
| 兼容 Rspack v2 | Add rspack 2.0 support |                |


## Checklist:

- [x] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [x] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `master` branch)
