### PR TITLE
chore: fix unplugin-react repository metadata

### DIFF
--- a/packages/unplugin-react/package.json
+++ b/packages/unplugin-react/package.json
@@ -9,8 +9,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:arco-design/arco-plugins.git",
-    "directory": "packages/plugin-unplugin-react"
+    "url": "git+https://github.com/arco-design/arco-plugins.git",
+    "directory": "packages/unplugin-react"
   },
   "scripts": {
     "build": "rm -rf lib && tsc",


### PR DESCRIPTION
## Summary

- update `@arco-plugins/unplugin-react` repository metadata to use the public HTTPS Git URL
- correct `repository.directory` from the stale `packages/plugin-unplugin-react` path to the actual `packages/unplugin-react` package path

## Why

The package currently points at `git@github.com:arco-design/arco-plugins.git`, which requires SSH, and its source `repository.directory` points at `packages/plugin-unplugin-react`, which does not exist in this repository. The package source lives in `packages/unplugin-react`.

## Validation

- `node -e "const p=require('./packages/unplugin-react/package.json'); if (p.repository.url !== 'git+https://github.com/arco-design/arco-plugins.git') throw new Error(p.repository.url); if (p.repository.directory !== 'packages/unplugin-react') throw new Error(p.repository.directory); console.log(JSON.stringify(p.repository))"`
- `git diff --check`
- `git ls-remote https://github.com/arco-design/arco-plugins.git HEAD`
- from `packages/unplugin-react`: `pnpm dlx npm@10.9.4 install --ignore-scripts --package-lock=false --workspaces=false`
- from `packages/unplugin-react`: `pnpm dlx npm@10.9.4 run build --workspaces=false`
- from `packages/unplugin-react`: `pnpm dlx npm@10.9.4 pack --dry-run --workspaces=false`

## Notes

I also tried the repository Yarn install, but the bundled Yarn Berry script fails locally on Node 24 while applying the TypeScript patch with `(0 , QO.isDate) is not a function`. I used package-level npm validation instead and did not change dependencies or lockfiles.
